### PR TITLE
Refine Doxygen embedder tokenization

### DIFF
--- a/crewai_tools/__init__.py
+++ b/crewai_tools/__init__.py
@@ -1,0 +1,9 @@
+from functools import wraps
+
+
+def tool(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tools/doxygen_embedder/README.md
+++ b/tools/doxygen_embedder/README.md
@@ -1,0 +1,7 @@
+# Doxygen Embedding Tool
+
+This tool processes a repository using Doxygen, extracts class documentation, generates vector embeddings for each text chunk, and stores the results in a Parquet file using **polars**.
+
+## Usage
+
+Call `doxygen_embedding_tool` with the repository path, output Parquet file, embedding service URL, and optional API key.

--- a/tools/doxygen_embedder/main.py
+++ b/tools/doxygen_embedder/main.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import xml.etree.ElementTree as ET
+
+import polars as pl
+import requests
+from crewai_tools import tool
+
+
+def _get_text(element: Optional[ET.Element]) -> str:
+    if element is None:
+        return ""
+    return " ".join(part.strip() for part in element.itertext()).strip()
+
+
+def _chunk_text(text: str, max_tokens: int) -> List[str]:
+    """Split *text* into overlapping chunks using token counts.
+
+    This function uses ``tiktoken`` to ensure that each chunk contains at most
+    ``max_tokens`` tokens. Adjacent chunks overlap by roughly 20% of the token
+    length to preserve context.
+    """
+
+    import tiktoken
+
+    enc = tiktoken.get_encoding("cl100k_base")
+    tokens = enc.encode(text)
+    if len(tokens) <= max_tokens:
+        return [text]
+
+    step = max(int(max_tokens * 0.8), 1)
+    chunks = []
+    for i in range(0, len(tokens), step):
+        chunk_tokens = tokens[i : i + max_tokens]
+        chunks.append(enc.decode(chunk_tokens))
+        if i + max_tokens >= len(tokens):
+            break
+    return chunks
+
+
+def _embed(text: str, base_url: str, api_key: Optional[str]) -> List[float]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    resp = requests.post(base_url, headers=headers, json={"text": text}, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    embedding = data.get("embedding")
+    if not isinstance(embedding, list):
+        raise ValueError("Invalid embedding response")
+    return embedding
+
+
+def _parse_member(
+    member: ET.Element, class_name: str, max_tokens: int
+) -> List[Dict[str, Any]]:
+    rows = []
+    member_name = _get_text(member.find("name")) or None
+    kind = member.get("kind", "member")
+    brief = _get_text(member.find("briefdescription"))
+    detailed = _get_text(member.find("detaileddescription"))
+
+    for section, text in [(f"{kind} brief", brief), (f"{kind} detailed", detailed)]:
+        if not text:
+            continue
+        for chunk in _chunk_text(text, max_tokens):
+            rows.append(
+                {
+                    "class_name": class_name,
+                    "section": section,
+                    "member_name": member_name,
+                    "text": chunk,
+                }
+            )
+    return rows
+
+
+def _parse_compound(compound: ET.Element, max_tokens: int) -> List[Dict[str, Any]]:
+    rows = []
+    class_name = _get_text(compound.find("compoundname"))
+    brief = _get_text(compound.find("briefdescription"))
+    detailed = _get_text(compound.find("detaileddescription"))
+
+    for section, text in [
+        ("brief description", brief),
+        ("detailed description", detailed),
+    ]:
+        if not text:
+            continue
+        for chunk in _chunk_text(text, max_tokens):
+            rows.append(
+                {
+                    "class_name": class_name,
+                    "section": section,
+                    "member_name": None,
+                    "text": chunk,
+                }
+            )
+
+    for member in compound.findall("memberdef"):
+        rows.extend(_parse_member(member, class_name, max_tokens))
+    return rows
+
+
+def _parse_xml(xml_dir: Path, max_tokens: int) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for path in xml_dir.glob("*.xml"):
+        tree = ET.parse(path)
+        root = tree.getroot()
+        for compound in root.findall("compounddef"):
+            kind = compound.get("kind")
+            if kind in {"class", "struct"}:
+                rows.extend(_parse_compound(compound, max_tokens))
+    return rows
+
+
+@tool
+def doxygen_embedding_tool(
+    repo_path: str,
+    output_file: str,
+    base_url: str,
+    api_key: str | None = None,
+    max_chunk_tokens: int = 8191,
+) -> str:
+    """Generate embeddings for Doxygen class documentation and save to Parquet.
+
+    Parameters
+    ----------
+    repo_path: Path to the repository to process.
+    output_file: Destination Parquet file path.
+    base_url: URL of the embedding service accepting POST {"text": str}.
+    api_key: Optional authorization token.
+    max_chunk_tokens: Maximum tokens per text chunk before splitting.
+
+    Returns
+    -------
+    Path to the generated Parquet file containing columns:
+    - class_name: class or struct name.
+    - section: documentation section.
+    - member_name: related member if applicable.
+    - text: documentation text chunk.
+    - embedding: embedding vector for the text.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        doxyfile = f"OUTPUT_DIRECTORY={tmpdir}\nGENERATE_XML=YES\nRECURSIVE=YES\nINPUT={repo_path}"
+        subprocess.run(
+            ["doxygen", "-"], input=doxyfile.encode(), cwd=repo_path, check=True
+        )
+        xml_dir = Path(tmpdir) / "xml"
+        rows = _parse_xml(xml_dir, max_chunk_tokens)
+    for row in rows:
+        row["embedding"] = _embed(row["text"], base_url, api_key)
+    df = pl.DataFrame(rows)
+    df.write_parquet(output_file)
+    return output_file

--- a/tools/doxygen_embedder/tests/test_main.py
+++ b/tools/doxygen_embedder/tests/test_main.py
@@ -1,0 +1,77 @@
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from tools.doxygen_embedder.main import doxygen_embedding_tool
+
+
+class DummyEncoding:
+    def encode(self, text: str) -> list[str]:
+        return text.split()
+
+    def decode(self, tokens: list[str]) -> str:
+        return " ".join(tokens)
+
+
+class DummyResponse:
+    def __init__(self, data: dict[str, Any]):
+        self._data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+def test_embedding_tool(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    xml_dir = tmp_path / "xml"
+    xml_dir.mkdir()
+    sample_xml = xml_dir / "sample.xml"
+    sample_xml.write_text(
+        """
+        <doxygen>
+          <compounddef kind='class'>
+            <compoundname>Example</compoundname>
+            <briefdescription><para>Brief.</para></briefdescription>
+            <detaileddescription><para>Detail text.</para></detaileddescription>
+            <memberdef kind='function'>
+              <name>foo</name>
+              <briefdescription><para>Foo brief</para></briefdescription>
+            </memberdef>
+          </compounddef>
+        </doxygen>
+        """,
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd, input=None, cwd=None, check=None):
+        # write xml to expected location
+        dest = Path(input.decode().split("OUTPUT_DIRECTORY=")[1].split("\n")[0]) / "xml"
+        dest.mkdir(parents=True, exist_ok=True)
+        for file in xml_dir.iterdir():
+            dest.joinpath(file.name).write_bytes(file.read_bytes())
+        return subprocess.CompletedProcess(cmd, 0)
+
+    def fake_post(url, headers=None, json=None, timeout=30):
+        return DummyResponse({"embedding": [0.1, 0.2]})
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("tiktoken.get_encoding", lambda name: DummyEncoding())
+
+    out_file = tmp_path / "out.parquet"
+    result = doxygen_embedding_tool(str(repo), str(out_file), "http://base")
+    assert Path(result).is_file()
+    df = pl.read_parquet(out_file)
+    assert {"class_name", "section", "member_name", "text", "embedding"} <= set(
+        df.columns
+    )

--- a/tools/doxygen_embedder/tool-spec.json
+++ b/tools/doxygen_embedder/tool-spec.json
@@ -1,0 +1,14 @@
+{
+  "name": "doxygen_embedding_tool",
+  "description": "Generate vector embeddings from Doxygen documentation and save them to Parquet",
+  "inputs": [
+    {"name": "repo_path", "type": "string", "description": "Path to the repository"},
+    {"name": "output_file", "type": "string", "description": "Destination Parquet file"},
+    {"name": "base_url", "type": "string", "description": "Embedding service URL"},
+    {"name": "api_key", "type": "string", "description": "Optional API key", "required": false},
+    {"name": "max_chunk_tokens", "type": "integer", "description": "Maximum tokens per chunk", "default": 8191}
+  ],
+  "outputs": [
+    {"name": "output_file", "type": "string", "description": "Path to the generated Parquet file"}
+  ]
+}


### PR DESCRIPTION
## Summary
- refine `_chunk_text` to use `tiktoken` for accurate token counts
- patch tests with a dummy encoding to keep them offline
- use `polars` for Parquet output

## Testing
- `ruff format tools/doxygen_embedder/main.py tools/doxygen_embedder/tests/test_main.py crewai_tools/__init__.py`
- `ruff check --fix tools/doxygen_embedder/main.py tools/doxygen_embedder/tests/test_main.py crewai_tools/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a79b71f0832389fef5742e42e774